### PR TITLE
Support .NET 5.0+ on windows, fix bug on windows & .NET Framework 4.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 run:
-	dotnet run --project src/PokepayPartnerCsharpSdk.Example/PokepayPartnerCsharpSdk.Example.csproj
+	dotnet run --project src/PokepayPartnerCsharpSdk.Example/PokepayPartnerCsharpSdk.Example.csproj --framework net5.0
 
 build:
-	dotnet build src/PokepayPartnerCsharpSdk/PokepayPartnerCsharpSdk.csproj --configuration Release
+	dotnet build src/PokepayPartnerCsharpSdk/PokepayPartnerCsharpSdk.csproj --configuration Release --framework net5.0
 
 test:
-	dotnet test -v normal src/PokepayPartnerCsharpSdk.Test/PokepayPartnerCsharpSdk.Test.csproj
+	dotnet test -v normal src/PokepayPartnerCsharpSdk.Test/PokepayPartnerCsharpSdk.Test.csproj --framework net5.0
 
 check-publish-env:
 ifndef RELEASE_VERSION

--- a/release.cmd
+++ b/release.cmd
@@ -1,0 +1,11 @@
+@echo off
+if not defined RELEASE_VERSION (
+  echo environment RELEASE_VERSION is required.
+  exit /b
+)
+if not defined API_KEY(
+  echo environment API_KEY is required.
+  exit /b
+)
+
+dotnet nuget push src/PokepayPartnerCsharpSdk/bin/Release/pokepay-partner-csharp-sdk.%RELEASE_VERSION%.nupkg --api-key %API_KEY% --source https://api.nuget.org/v3/index.json

--- a/src/PokepayPartnerCsharpSdk/Client.cs
+++ b/src/PokepayPartnerCsharpSdk/Client.cs
@@ -84,11 +84,12 @@ namespace PokepayPartnerCsharpSdk
 
         private static HttpClient GetHttpClient(string certPem, string rsaKeyPem) {
 #if NETFRAMEWORK
-            X509Certificate2 cert = X509FromPemFile.CreateFromPemFile(certPem, rsaKeyPem);
+            byte[] pfx = (new X509Certificate2Collection(X509FromPemFile.CreateFromPemFile(certPem, rsaKeyPem))).Export(X509ContentType.Pfx);
 #else
             // see https://www.daimto.com/how-to-use-x509certificate2-with-pem-file/
-            X509Certificate2 cert = new X509Certificate2((X509Certificate2.CreateFromPemFile(certPem, rsaKeyPem)).Export(X509ContentType.Pfx));
+            byte[] pfx = X509Certificate2.CreateFromPemFile(certPem, rsaKeyPem).Export(X509ContentType.Pfx);
 #endif
+            X509Certificate2 cert = new X509Certificate2(pfx);
             HttpClientHandler handler = new HttpClientHandler();
             handler.ClientCertificates.Clear();
             handler.ClientCertificates.Add(cert);

--- a/src/PokepayPartnerCsharpSdk/Client.cs
+++ b/src/PokepayPartnerCsharpSdk/Client.cs
@@ -86,9 +86,9 @@ namespace PokepayPartnerCsharpSdk
 #if NETFRAMEWORK
             X509Certificate2 cert = X509FromPemFile.CreateFromPemFile(certPem, rsaKeyPem);
 #else
-            X509Certificate2 cert = X509Certificate2.CreateFromPemFile(certPem, rsaKeyPem);
+            // see https://www.daimto.com/how-to-use-x509certificate2-with-pem-file/
+            X509Certificate2 cert = new X509Certificate2((X509Certificate2.CreateFromPemFile(certPem, rsaKeyPem)).Export(X509ContentType.Pfx));
 #endif
-
             HttpClientHandler handler = new HttpClientHandler();
             handler.ClientCertificates.Clear();
             handler.ClientCertificates.Add(cert);

--- a/src/PokepayPartnerCsharpSdk/PokepayPartnerCsharpSdk.csproj
+++ b/src/PokepayPartnerCsharpSdk/PokepayPartnerCsharpSdk.csproj
@@ -8,7 +8,7 @@
     <Company>PocketChange.inc</Company>
     <PackageProjectUrl>https://github.com/pokepay/pokepay-partner-csharp-sdk</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <OutputType>Library</OutputType>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>

--- a/src/PokepayPartnerCsharpSdk/X509FromPemFile.cs
+++ b/src/PokepayPartnerCsharpSdk/X509FromPemFile.cs
@@ -18,10 +18,8 @@ namespace PokepayPartnerCsharpSdk
             RSACryptoServiceProvider prov = new RSACryptoServiceProvider();
             byte[] keyBuffer = GetBytesFromPEM(File.ReadAllText(rsaKeyPem), "-----BEGIN RSA PRIVATE KEY-----", "-----END RSA PRIVATE KEY-----");
             prov.ImportParameters(CreateParameter(keyBuffer));
-            cert.PrivateKey = prov;
-            cert.GetRSAPrivateKey(); // important!
 
-            return cert;
+            return cert.CopyWithPrivateKey(prov);
         }
 
         private static byte[] GetBytesFromPEM(string pemString, string header, string footer)


### PR DESCRIPTION
[X509Certificate](https://docs.microsoft.com/ja-jp/dotnet/api/system.security.cryptography.x509certificates.x509certificate) looks file-format-independent in .NET document. It provides many constructors.

However, internal implementation of [X509Certificate](https://docs.microsoft.com/ja-jp/dotnet/api/system.security.cryptography.x509certificates.x509certificate) is [CERT_CONTEXT](https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-cert_context)
and other related methods like HttpClient may require pfx format.

We should use constructor with pfx byte array on windows.