### PR TITLE
use request_method json parameter instead of http method.

### DIFF
--- a/src/PokepayPartnerCsharpSdk/Client.cs
+++ b/src/PokepayPartnerCsharpSdk/Client.cs
@@ -25,12 +25,13 @@ namespace PokepayPartnerCsharpSdk
 
     public class SendBodyData
     {
+        public string RequestMethod { get; }
         public string Data { get; }
         public string PartnerClientId { get; }
 
         [JsonConstructor]
-        public SendBodyData(string data, string partnerClientId) =>
-            (Data, PartnerClientId) = (data, partnerClientId);
+        public SendBodyData(string requestMethod, string data, string partnerClientId) =>
+            (RequestMethod, Data, PartnerClientId) = (requestMethod, data, partnerClientId);
     }
 
     public class ReceiveBodyData
@@ -132,13 +133,14 @@ namespace PokepayPartnerCsharpSdk
             string requestBodyEnc = Encrypter.EncryptData(requestBodyString, ClientSecret);
 
             SendBodyData sendBodyData = new SendBodyData(
+                method.ToString(),
                 requestBodyEnc,
                 ClientId);
 
             string sendBodyString = JsonSerializer.Serialize(sendBodyData, JsonOptions);
 
             HttpRequestMessage request = new HttpRequestMessage {
-                Method = method,
+                Method = HttpMethod.Post,
                 RequestUri = new Uri(BaseUrl + path),
                 Content = new StringContent(sendBodyString, System.Text.Encoding.UTF8, "application/json"),
             };

--- a/src/PokepayPartnerCsharpSdk/PokepayPartnerCsharpSdk.csproj
+++ b/src/PokepayPartnerCsharpSdk/PokepayPartnerCsharpSdk.csproj
@@ -8,7 +8,7 @@
     <Company>PocketChange.inc</Company>
     <PackageProjectUrl>https://github.com/pokepay/pokepay-partner-csharp-sdk</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.1.1</Version>
+    <Version>1.1.2</Version>
     <OutputType>Library</OutputType>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>


### PR DESCRIPTION
[internal implementation of HttpClient on .NET Framework 4.8 does not support content type when HTTP GET method](https://docs.microsoft.com/ja-jp/dotnet/api/system.net.httpwebrequest.getrequeststream?view=netframework-4.8).
This sdk uses HTTP POST method and request_method parameter in json structure.